### PR TITLE
Fix HMR hot swapping issue.  Not swapping in all changes.

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -868,6 +868,30 @@
         "minimist": "^1.2.0"
       }
     },
+    "@hot-loader/react-dom": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-MsOdCBB7c5YNyB4iDDct+tS7AihvYyfwZVV+z/QnbTjPgxH98kqIDXO92nU7tLXp0OtYFErHZfcWjtszP/572w==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.15.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+          "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -5723,9 +5723,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
+      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -42,6 +42,7 @@
     "@babel/polyfill": "7.4.4",
     "@babel/preset-env": "7.4.5",
     "@babel/preset-react": "7.0.0",
+    "@hot-loader/react-dom": "16.9.0",
     "@types/enzyme": "3.10.3",
     "@types/jest": "24.0.18",
     "@types/react-hot-loader": "4.1.0",

--- a/demo/src/client/HelloWorldPage/dev.tsx
+++ b/demo/src/client/HelloWorldPage/dev.tsx
@@ -16,9 +16,8 @@ const render = () => {
 
 declare const module: any;
 
-window.addEventListener('DOMContentLoaded', (event) => {
-    render();
-    if (module.hot) {
-        module.hot.accept();
-    }
-});
+if (module.hot) {
+    module.hot.accept();
+}
+
+render();

--- a/demo/webpack/dev.config.js
+++ b/demo/webpack/dev.config.js
@@ -60,7 +60,10 @@ module.exports = {
     },
 
     resolve: {
-        extensions: constants.extensions.TYPESCRIPT
+        extensions: constants.extensions.TYPESCRIPT,
+        alias: {
+            'react-dom': '@hot-loader/react-dom'
+        }
     },
 
     module: {


### PR DESCRIPTION
Remove event handler from dev.tsx as it seemed to be interfering with hot module reloading.  This handler was added to allow LK page with container element to load first, but looks like not necessary because dev server loads slower than page loads, unlike production server.   Also add @hot-loader/react-dom to clear up "React-Hot-Loader: react-🔥-dom patch is not detected" warning.