### PR TITLE
appendNavTrail() to addNavTrail() migration

### DIFF
--- a/demo/src/org/labkey/demo/DemoContainerListener.java
+++ b/demo/src/org/labkey/demo/DemoContainerListener.java
@@ -30,6 +30,7 @@ import java.sql.SQLException;
  */
 public class DemoContainerListener extends ContainerManager.AbstractContainerListener
 {
+    @Override
     public void containerDeleted(Container c, User user)
     {
         DemoManager.getInstance().deleteAllData(c);

--- a/demo/src/org/labkey/demo/DemoController.java
+++ b/demo/src/org/labkey/demo/DemoController.java
@@ -321,11 +321,13 @@ public class DemoController extends SpringActionController
     @RequiresPermission(DeletePermission.class)
     public class DeleteAction extends FormViewAction
     {
+        @Override
         public HttpView getView(Object o, boolean reshow, BindException errors)
         {
             throw new RedirectException(getSuccessURL(o));
         }
 
+        @Override
         public boolean handlePost(Object o, BindException errors)
         {
             Set<Integer> personIds = DataRegionSelection.getSelectedIntegers(getViewContext(), true);
@@ -334,15 +336,18 @@ public class DemoController extends SpringActionController
             return true;
         }
 
+        @Override
         public void validateCommand(Object o, Errors errors)
         {
         }
 
+        @Override
         public ActionURL getSuccessURL(Object o)
         {
             return new BeginAction().getURL();
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }
@@ -646,6 +651,7 @@ public class DemoController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class BindAction extends SimpleViewAction<BindActionBean>
     {
+        @Override
         public ModelAndView handleRequest() throws Exception
         {
             // if no values were posted, use test parameters
@@ -686,11 +692,13 @@ public class DemoController extends SpringActionController
             return super.handleRequest();
         }
 
+        @Override
         public ModelAndView getView(BindActionBean form, BindException errors)
         {
             return new JspView<>("/org/labkey/demo/view/bindTest.jsp", form, errors);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
             root.addChild(getPageTitle());

--- a/demo/src/org/labkey/demo/DemoController.java
+++ b/demo/src/org/labkey/demo/DemoController.java
@@ -97,10 +97,9 @@ public class DemoController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Demo", getURL());
-            return root;
         }
 
         public ActionURL getURL()
@@ -150,12 +149,10 @@ public class DemoController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Demo", new ActionURL(BeginAction.class, getContainer()));
             root.addChild("Insert Person");
-
-            return root;
         }
 
         public ActionURL getURL()
@@ -222,12 +219,10 @@ public class DemoController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Demo", new ActionURL(BeginAction.class, getContainer()));
             root.addChild(getPageTitle());
-
-            return root;
         }
 
         public String getPageTitle()
@@ -306,12 +301,10 @@ public class DemoController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Demo", new ActionURL(BeginAction.class, getContainer()));
             root.addChild("Bulk Update");
-
-            return root;
         }
 
         public ActionURL getURL()
@@ -350,9 +343,8 @@ public class DemoController extends SpringActionController
             return new BeginAction().getURL();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -699,12 +691,10 @@ public class DemoController extends SpringActionController
             return new JspView<>("/org/labkey/demo/view/bindTest.jsp", form, errors);
         }
 
-
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild(getPageTitle());
+            root.addChild(getPageTitle());
         }
-
 
         public String getPageTitle()
         {


### PR DESCRIPTION
#### Rationale
Adjust actions to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. Also, bulk annotate with @Override. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199