### PR TITLE
Item 7490: remove unused log4j reference

### DIFF
--- a/demo/src/org/labkey/demo/view/DemoWebPart.java
+++ b/demo/src/org/labkey/demo/view/DemoWebPart.java
@@ -16,7 +16,6 @@
 
 package org.labkey.demo.view;
 
-import org.apache.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
@@ -34,8 +33,6 @@ import java.util.List;
  */
 public class DemoWebPart extends JspView<List<Person>>
 {
-    private static final Logger _log = Logger.getLogger(DemoWebPart.class);
-
     public DemoWebPart()
     {
         super("/org/labkey/demo/view/demoWebPart.jsp", null);


### PR DESCRIPTION
#### Rationale
This PR removes the unused reference of log4j as a part of log4j upgrade.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1378

