### PR TITLE
Add Release workflow definitions

### DIFF
--- a/.github/workflows/branch_release.yml
+++ b/.github/workflows/branch_release.yml
@@ -1,0 +1,23 @@
+---
+# Workflow to automate creation and updating of release branches
+name: Release Branching
+
+# Trigger on tags created by TeamCity
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  branch_release:
+    if: github.event.created && github.event.sender.login == 'labkey-teamcity'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create branches and PRs
+        uses: LabKey/gitHubActions/branch-release@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge_release.yml
+++ b/.github/workflows/merge_release.yml
@@ -1,0 +1,28 @@
+---
+# Workflow to automate merging release branches
+name: Release Merging
+
+# Trigger on PR approval
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  merge_release:
+    if: >
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.user.login == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Merge PR
+        uses: LabKey/gitHubActions/merge-release@master
+        with:
+          target_branch: ${{ github.event.pull_request.base.ref }}
+          merge_branch: ${{ github.event.pull_request.head.ref }}
+          pr_number: ${{ github.event.pull_request.number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Rationale
This repository didn't have SNAPSHOT branches because it changes so infrequently. Using our standard branching and release process will save several extra configuration steps for each release.

#### Changes
* Add GitHub release workflows
