### PR TITLE
Fb jsp final

### DIFF
--- a/demo/src/org/labkey/demo/view/bindTest.jsp
+++ b/demo/src/org/labkey/demo/view/bindTest.jsp
@@ -45,8 +45,8 @@
     {
         %><table><%
         %><tr><td>d</td><td><input name="d" value="<%=formatDateTime(form.getD())%>"></td><td><%=h(getMessage(errors.getFieldError("d")))%></td></tr><%
-        %><tr><td>i</td><td><input name="i" value="<%=h(form.getI())%>"></td><td><%=h(getMessage(errors.getFieldError("i")))%></td></tr><%
-        %><tr><td>j</td><td><input name="j" value="<%=h(form.getJ())%>"></td><td><%=h(getMessage(errors.getFieldError("j")))%></td></tr><%
+        %><tr><td>i</td><td><input name="i" value="<%=form.getI()%>"></td><td><%=h(getMessage(errors.getFieldError("i")))%></td></tr><%
+        %><tr><td>j</td><td><input name="j" value="<%=form.getJ()%>"></td><td><%=h(getMessage(errors.getFieldError("j")))%></td></tr><%
         %><tr><td>k</td><td><input name="k" value="<%=h(form.getK())%>"></td><td><%=h(getMessage(errors.getFieldError("k")))%></td></tr><%
         %><tr><td>l</td><td><input name="l" value="<%=h(form.getL())%>"></td><td><%=h(getMessage(errors.getFieldError("l")))%></td></tr><%
         %><tr><td>s</td><td><input name="s" value="<%=h(form.getS())%>"></td><td><%=h(getMessage(errors.getFieldError("s")))%></td></tr><%
@@ -56,8 +56,8 @@
         %><tr><td>multiString[2]</td><td><input name="multiString" value="<%=h(_get(form.getMultiString(),2))%>"></td><td><%=h(getMessage(errors.getFieldError("multiString[2]")))%></td></tr><%
         %><tr><td>sub</td><td><input disabled value="<%=h(form.getSub())%>"></td><td><%=h(getMessage(errors.getFieldError("sub")))%></td></tr><%
         %><tr><td>sub.s</td><td><input name="sub.s" value="<%=h(form.getSub().getS())%>"></td><td><%=h(getMessage(errors.getFieldError("sub.s")))%></td></tr><%
-        %><tr><td>sub.x</td><td><input name="sub.x" value="<%=h(form.getSub().getX())%>"></td><td><%=h(getMessage(errors.getFieldError("sub.x")))%></td></tr><%
-        %><tr><td>sub.y</td><td><input name="sub.y" value="<%=h(form.getSub().getY())%>"></td><td><%=h(getMessage(errors.getFieldError("sub.y")))%></td></tr><%
+        %><tr><td>sub.x</td><td><input name="sub.x" value="<%=form.getSub().getX()%>"></td><td><%=h(getMessage(errors.getFieldError("sub.x")))%></td></tr><%
+        %><tr><td>sub.y</td><td><input name="sub.y" value="<%=form.getSub().getY()%>"></td><td><%=h(getMessage(errors.getFieldError("sub.y")))%></td></tr><%
 
         %><tr><td>listString[0]</td><td><input name="listString[0]" value="<%=h(_get(form.getListString(),0))%>"></td><td><%=h(getMessage(errors.getFieldError("listString[0]")))%></td></tr><%
         %><tr><td>listString[1]</td><td><input name="listString[1]" value="<%=h(_get(form.getListString(),1))%>"></td><td><%=h(getMessage(errors.getFieldError("listString[1]")))%></td></tr><%

--- a/demo/src/org/labkey/demo/view/bulkUpdate.jsp
+++ b/demo/src/org/labkey/demo/view/bulkUpdate.jsp
@@ -17,13 +17,14 @@
 %>
 <%@ page import="org.labkey.api.view.HttpView"%>
 <%@ page import="org.labkey.api.view.JspView"%>
+<%@ page import="org.labkey.demo.DemoController" %>
+<%@ page import="org.labkey.demo.DemoController.BulkUpdateAction" %>
 <%@ page import="org.labkey.demo.model.Person" %>
 <%@ page import="org.springframework.validation.Errors" %>
 <%@ page import="org.springframework.validation.ObjectError" %>
 <%@ page import="java.util.HashSet" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Set" %>
-<%@ page import="org.labkey.demo.DemoController" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -48,7 +49,7 @@
     if (people.size() > 0)
     {
 %>
-    <labkey:form action="bulkUpdate.post" method="POST">
+    <labkey:form action="<%=urlFor(BulkUpdateAction.class)%>" method="POST">
         <table>
             <tr>
                 <th>First Name</th>

--- a/demo/src/org/labkey/demo/view/demoWebPart.jsp
+++ b/demo/src/org/labkey/demo/view/demoWebPart.jsp
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.view.ActionURL"%>
-<%@ page import="org.labkey.api.view.HttpView" %>
-<%@ page import="org.labkey.demo.DemoController" %>
+<%@ page import="org.labkey.api.view.HttpView"%>
+<%@ page import="org.labkey.demo.DemoController.BeginAction" %>
 <%@ page import="org.labkey.demo.model.Person" %>
 <%@ page import="java.util.List" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -25,4 +24,4 @@
     List<Person> people = (List<Person>) (HttpView.currentModel());
 %>
 This folder contains <%= people.size() %> people.<br>
-<%= button("View Grid").href(new ActionURL(DemoController.BeginAction.class, getContainer())) %>
+<%= button("View Grid").href(urlFor(BeginAction.class)) %>


### PR DESCRIPTION
#### Rationale
Use `urlFor()` instead of hard-coded strings and `new ActionURL()`. Stop encoding ints.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1549