### PR TITLE
Add build.gradle file in anticipation of removal of modules/build.gradle

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.module'
+}

--- a/exampleassay/build.gradle
+++ b/exampleassay/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.fileModule'
+}

--- a/interactiveTutorial/build.gradle
+++ b/interactiveTutorial/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.fileModule'
+}


### PR DESCRIPTION
#### Rationale
We plan to remove the `server/modules/build.gradle` file that has logic to apply plugins for subprojects since that logic is only a heuristic and fails to do the right thing for file-based modules that include only client source code.  Instead, we will update each module's own `build.gradle` file so it applies the appropriate plugins (and add `build.gradle` files where there are none).  

#### Changes
* apply module plugin in build.gradle file