### PR TITLE
Comment out custom standalone module version

### DIFF
--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -22,7 +22,8 @@ plugins {
     id 'org.labkey.build.module'
 }
 
-project.version="0.0.1-SNAPSHOT" // this can use your own versioning scheme
+// this can use your own versioning scheme
+// project.version="0.0.1-SNAPSHOT"
 
 dependencies
         {


### PR DESCRIPTION
#### Rationale
These modules all get published. When we attempt to publish non-snapshot releases, Artifactory rejects the `0.0.1-SNAPSHOT` version of the standalone module.

#### Related Pull Requests
* #49 

#### Changes
* Comment out standalone `project.version` and inherit `labkeyVersion` for the module's version
