### PR TITLE
Don't override labkeyVersion property

### DIFF
--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -6,7 +6,8 @@ artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 gradlePluginsVersion=1.27.0
 
 # versions of artifacts required as dependencies
-# labkeyVersion=21.3.4 #disabled to work with standard build
+#uncomment the version number and set to the desired labkeyVersion
+#labkeyVersion=21.3.4
 labkeyClientApiVersion=1.3.2
 
 # used by the LabKey Jsp Gradle plugin for declaring dependencies

--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -3,10 +3,10 @@ artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
 # Version 1.17.0 or higher is required to fully support building stand-alone modules with the LabKey Gradle plugins
 # Exact version will vary based on the version of LabKey being built on
-gradlePluginsVersion=1.27.0_standaloneBuild-SNAPSHOT
+gradlePluginsVersion=1.27.0
 
 # versions of artifacts required as dependencies
-labkeyVersion=21.3.4
+# labkeyVersion=21.3.4 #disabled to work with standard build
 labkeyClientApiVersion=1.3.2
 
 # used by the LabKey Jsp Gradle plugin for declaring dependencies

--- a/standalone/settings.gradle
+++ b/standalone/settings.gradle
@@ -21,6 +21,10 @@ buildscript {
 // This ensures that the module name is correct when cloned to a non-standard directory
 rootProject.name="standalone"
 
+if (!hasProperty("labkeyVersion")) {
+    throw new GradleException("Define 'labkeyVersion' in 'gradle.properties' to build outside of a standard LabKey enlistment")
+}
+
 gradle.beforeProject { project ->
     project.repositories {
         maven {


### PR DESCRIPTION
#### Rationale
Setting the `labkeyVersion` property is causing the installer build to fail when it tries to publish to Artifactory. I'd prefer to just disable publishing for this module but that doesn't seem to be possible without some changes to our gradle plugins.

#### Changes
* Comment out `labkeyVersion` in gradle properties
* Use release version of LabKey gradle plugins
