### PR TITLE
Remove dependency on published module

### DIFF
--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -27,6 +27,7 @@ plugins {
 
 dependencies
         {
-            implementation "org.labkey.api:issues:${labkeyVersion}" // An example of declaring a dependency on the API jar for a module
+            // An example of declaring a dependency on the API jar for a module
+            // implementation "org.labkey.api:issues:${labkeyVersion}"
             external "commons-beanutils:commons-beanutils:${commonsBeanutilsVersion}" // An external dependency to be included in the module's lib directory
         }


### PR DESCRIPTION
#### Rationale
Having a dependency on the published issues module causes the first build of a release to fail because that version of the module has not been published yet.

#### Changes
* Comment out example dependency declaration
