### PR TITLE
Dependency version update for 21.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ demo/node_modules
 demo/resources/web/demo/gen
 demo/resources/views/gen
 dependencies.txt
+jars.txt
 enlistment.properties
 build/
 
 # Gradle
 .gradle
+

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -2993,7 +2993,7 @@
     },
     "@labkey/api": {
       "version": "1.5.0",
-      "resolved": "http://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.5.0.tgz",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.5.0.tgz",
       "integrity": "sha1-iew0iZBBUdnxYA5Nk7QjuHHdAh4="
     },
     "@labkey/build": {

--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -16,6 +16,7 @@
 // See the Gradle documentation for more information (https://docs.gradle.org).
 //
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 plugins {
     // This plugin brings in the standard tasks for building a LabKey Java module that may include JSPs, XSDs, or npm builds
@@ -27,5 +28,18 @@ project.version="0.0.1-SNAPSHOT" // this can use your own versioning scheme
 dependencies
         {
             implementation "org.labkey.api:issues:${labkeyVersion}" // An example of declaring a dependency on the API jar for a module
-            external "commons-beanutils:commons-beanutils:${commonsBeanutilsVersion}" // An external dependency to be included in the module's lib directory
+
+            // An external dependency to be included in the module's lib directory
+            BuildUtils.addExternalDependency(
+                    project,
+                    new ExternalDependency(
+                            "commons-beanutils:commons-beanutils:${commonsBeanutilsVersion}",
+                            "Commons Beanutils",
+                            "Apache",
+                            "http://jakarta.apache.org/commons/beanutils/",
+                            ExternalDependency.APACHE_2_LICENSE_NAME,
+                            ExternalDependency.APACHE_2_LICENSE_URL,
+                            "Reading/writing beans"
+                    )
+            )
         }

--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -14,4 +14,4 @@ apacheTomcatVersion=8.5.51
 servletApiVersion=3.0
 
 # Example external dependency used in build file
-commonsBeanutilsVersion=1.7.0
+commonsBeanutilsVersion=1.8.3


### PR DESCRIPTION
#### Rationale
Keeping dependency versions updated.  We also take this opportunity to transition some of the modules to use the new `BuildUtils.addExternalDependency` method that provides the information to be used in populating the `jars.txt` file so we can remove it from and ignore it in git.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2352

#### Changes
* Use `BuildUtils.addExternalDependency`, bringing in version updates.