### PR TITLE
Update artifactory URL for 22.3

### DIFF
--- a/demo/.npmrc
+++ b/demo/.npmrc
@@ -1,2 +1,2 @@
 # Set registry for @labkey scopes
-@labkey:registry=https://artifactory.labkey.com/artifactory/api/npm/libs-client/
+@labkey:registry=https://labkey.jfrog.io/artifactory/api/npm/libs-client/

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -2756,13 +2756,13 @@
     },
     "node_modules/@labkey/api": {
       "version": "1.7.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.2.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.2.tgz",
       "integrity": "sha1-2G4KoFl6rLWxGVuh2qPmiwd7RdM=",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-5.0.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-5.0.1.tgz",
       "integrity": "sha1-6eEqx45lpOjriEge9CRZXSSH1Fs=",
       "dev": true,
       "license": "Apache-2.0",
@@ -2807,7 +2807,7 @@
     },
     "node_modules/@labkey/components": {
       "version": "2.115.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.115.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.115.1.tgz",
       "integrity": "sha1-PW6ZxQrUxDKc+a/rodhn1O47sSI=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -19548,12 +19548,12 @@
     },
     "@labkey/api": {
       "version": "1.7.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.2.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.2.tgz",
       "integrity": "sha1-2G4KoFl6rLWxGVuh2qPmiwd7RdM="
     },
     "@labkey/build": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-5.0.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-5.0.1.tgz",
       "integrity": "sha1-6eEqx45lpOjriEge9CRZXSSH1Fs=",
       "dev": true,
       "requires": {
@@ -19599,7 +19599,7 @@
     },
     "@labkey/components": {
       "version": "2.115.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.115.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.115.1.tgz",
       "integrity": "sha1-PW6ZxQrUxDKc+a/rodhn1O47sSI=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",

--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -1,5 +1,5 @@
 # Location of the repository for various artifacts used in the build
-artifactory_contextUrl=https://artifactory.labkey.com/artifactory
+artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 # Version 1.17.0 or higher is required to fully support building stand-alone modules with the LabKey Gradle plugins
 # Exact version will vary based on the version of LabKey being built on


### PR DESCRIPTION
#### Rationale
Artifactory migration

#### Related Pull Requests
* [Server](https://github.com/LabKey/server/pull/280)

#### Changes
* Update artifactory url in package.json and package-lock.json