### PR TITLE
Update artifactory URL for 21.11

### DIFF
--- a/demo/.npmrc
+++ b/demo/.npmrc
@@ -1,2 +1,2 @@
 # Set registry for @labkey scopes
-@labkey:registry=https://artifactory.labkey.com/artifactory/api/npm/libs-client/
+@labkey:registry=https://labkey.jfrog.io/artifactory/api/npm/libs-client/

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -2453,12 +2453,12 @@
     },
     "@labkey/api": {
       "version": "1.6.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
       "integrity": "sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I="
     },
     "@labkey/build": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-4.0.1.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-4.0.1.tgz",
       "integrity": "sha1-kFy1gVVYNBoJNZ6A6FWZnMXtwTM=",
       "dev": true,
       "requires": {
@@ -2504,7 +2504,7 @@
     },
     "@labkey/components": {
       "version": "2.68.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.68.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.68.0.tgz",
       "integrity": "sha1-hvg9RrZ/faV0RfhDpWRkQaNWDYY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",

--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -1,5 +1,5 @@
 # Location of the repository for various artifacts used in the build
-artifactory_contextUrl=https://artifactory.labkey.com/artifactory
+artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 # Version 1.17.0 or higher is required to fully support building stand-alone modules with the LabKey Gradle plugins
 # Exact version will vary based on the version of LabKey being built on


### PR DESCRIPTION
#### Rationale
Artifactory migration

#### Related Pull Requests
* [Server](https://github.com/LabKey/server/pull/281)

#### Changes
* Update artifactory url in package.json and package-lock.json