### PR TITLE
FileAttachmentForm demo page update to include example usage of createWebDavDirectory()

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "demo",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.218.2"
+        "@labkey/components": "2.220.0-fb-webDavCreateDir46185.0"
       },
       "devDependencies": {
         "@labkey/build": "6.2.1",
@@ -2941,9 +2941,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.15.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.15.0.tgz",
-      "integrity": "sha1-OZEawkPKPCranyrgekMhPokH4A0=",
+      "version": "1.16.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.16.1.tgz",
+      "integrity": "sha512-OVHhObWPVu7w/6pDXHBo3uaRRfDztmAY31/X8omx2BV+AHPNplFwxORUjQFgIsBHj6u79T44ZpJLETdxuR2sSg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2983,9 +2983,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.218.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.218.2.tgz",
-      "integrity": "sha512-YKxY6YQ0T0gQPMcieTbbQnxw5PqVQ26vNq/FNz7xltKRFHpkrtFPFfeTG9s0jEvmReEpBXWqCnTDqVpsTgyJ/A==",
+      "version": "2.220.0-fb-webDavCreateDir46185.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.220.0-fb-webDavCreateDir46185.0.tgz",
+      "integrity": "sha512-VOVETiQMAKsVzvf0VpPECKk19ezNJtmSq2jcjzGoQa5KHcR0nMKyWR4lmSf/nEE2KwVCm+HxPai4fuhYv7I9BA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "~5.15.4",
@@ -2993,7 +2993,7 @@
         "@fortawesome/free-regular-svg-icons": "~5.15.4",
         "@fortawesome/free-solid-svg-icons": "~5.15.4",
         "@fortawesome/react-fontawesome": "~0.1.15",
-        "@labkey/api": "~1.15.0",
+        "@labkey/api": "~1.16.1",
         "@types/enzyme": "~3.10.11",
         "@types/jest": "~28.1.6",
         "bootstrap": "~3.4.1",
@@ -15797,9 +15797,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.15.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.15.0.tgz",
-      "integrity": "sha1-OZEawkPKPCranyrgekMhPokH4A0="
+      "version": "1.16.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.16.1.tgz",
+      "integrity": "sha512-OVHhObWPVu7w/6pDXHBo3uaRRfDztmAY31/X8omx2BV+AHPNplFwxORUjQFgIsBHj6u79T44ZpJLETdxuR2sSg=="
     },
     "@labkey/build": {
       "version": "6.2.1",
@@ -15837,16 +15837,16 @@
       }
     },
     "@labkey/components": {
-      "version": "2.218.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.218.2.tgz",
-      "integrity": "sha512-YKxY6YQ0T0gQPMcieTbbQnxw5PqVQ26vNq/FNz7xltKRFHpkrtFPFfeTG9s0jEvmReEpBXWqCnTDqVpsTgyJ/A==",
+      "version": "2.220.0-fb-webDavCreateDir46185.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.220.0-fb-webDavCreateDir46185.0.tgz",
+      "integrity": "sha512-VOVETiQMAKsVzvf0VpPECKk19ezNJtmSq2jcjzGoQa5KHcR0nMKyWR4lmSf/nEE2KwVCm+HxPai4fuhYv7I9BA==",
       "requires": {
         "@fortawesome/fontawesome-free": "~5.15.4",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",
         "@fortawesome/free-regular-svg-icons": "~5.15.4",
         "@fortawesome/free-solid-svg-icons": "~5.15.4",
         "@fortawesome/react-fontawesome": "~0.1.15",
-        "@labkey/api": "~1.15.0",
+        "@labkey/api": "~1.16.1",
         "@types/enzyme": "~3.10.11",
         "@types/jest": "~28.1.6",
         "bootstrap": "~3.4.1",

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "demo",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.220.0-fb-webDavCreateDir46185.0"
+        "@labkey/components": "2.222.0"
       },
       "devDependencies": {
         "@labkey/build": "6.2.1",
@@ -2983,9 +2983,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.220.0-fb-webDavCreateDir46185.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.220.0-fb-webDavCreateDir46185.0.tgz",
-      "integrity": "sha512-VOVETiQMAKsVzvf0VpPECKk19ezNJtmSq2jcjzGoQa5KHcR0nMKyWR4lmSf/nEE2KwVCm+HxPai4fuhYv7I9BA==",
+      "version": "2.222.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.222.0.tgz",
+      "integrity": "sha512-B5BamEkl4QdgCmO8AksBpHkjbQQ17n6mpbIAAcT8JLXCGdQ30wi24MRr3WTf4mIImPgeshswU37T+TQSv3Ea5Q==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "~5.15.4",
@@ -15837,9 +15837,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.220.0-fb-webDavCreateDir46185.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.220.0-fb-webDavCreateDir46185.0.tgz",
-      "integrity": "sha512-VOVETiQMAKsVzvf0VpPECKk19ezNJtmSq2jcjzGoQa5KHcR0nMKyWR4lmSf/nEE2KwVCm+HxPai4fuhYv7I9BA==",
+      "version": "2.222.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.222.0.tgz",
+      "integrity": "sha512-B5BamEkl4QdgCmO8AksBpHkjbQQ17n6mpbIAAcT8JLXCGdQ30wi24MRr3WTf4mIImPgeshswU37T+TQSv3Ea5Q==",
       "requires": {
         "@fortawesome/fontawesome-free": "~5.15.4",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",

--- a/demo/package.json
+++ b/demo/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
-    "@labkey/components": "2.220.0-fb-webDavCreateDir46185.0"
+    "@labkey/components": "2.222.0"
   },
   "devDependencies": {
     "@labkey/build": "6.2.1",

--- a/demo/package.json
+++ b/demo/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
-    "@labkey/components": "2.218.2"
+    "@labkey/components": "2.220.0-fb-webDavCreateDir46185.0"
   },
   "devDependencies": {
     "@labkey/build": "6.2.1",

--- a/demo/src/client/FileAttachmentPage/CreateDirectoryModal.tsx
+++ b/demo/src/client/FileAttachmentPage/CreateDirectoryModal.tsx
@@ -6,7 +6,7 @@ interface Props {
     submit: (name: string) => void;
 }
 
-export const CreateSubfolderModal : FC<Props> = memo(props => {
+export const CreateDirectoryModal : FC<Props> = memo(props => {
     const { close, submit } = props;
     const [name, setName] = useState<string>('');
 
@@ -20,15 +20,15 @@ export const CreateSubfolderModal : FC<Props> = memo(props => {
 
     return (
         <Modal show={true} onHide={close}>
-            <Modal.Header>Create Subfolder</Modal.Header>
+            <Modal.Header>Create Directory</Modal.Header>
             <Modal.Body>
                 <Form>
                     <Row className="form-group">
                         <Col xs={4}>
-                            <div>Subfolder Name:</div>
+                            <div>Directory Name:</div>
                         </Col>
                         <Col xs={8}>
-                            <FormControl type="text" id={'subfolder-name'} name={'subfolder-name'} onChange={onChange} />
+                            <FormControl type="text" id={'directory-name'} name={'directory-name'} onChange={onChange} />
                         </Col>
                     </Row>
                 </Form>

--- a/demo/src/client/FileAttachmentPage/CreateSubfolderModal.tsx
+++ b/demo/src/client/FileAttachmentPage/CreateSubfolderModal.tsx
@@ -1,0 +1,53 @@
+import React, { FC, memo, useCallback, useState } from 'react';
+import { Button, Col, Form, FormControl, Modal, Row } from 'react-bootstrap';
+
+interface Props {
+    close: () => void;
+    submit: (name: string) => void;
+}
+
+export const CreateSubfolderModal : FC<Props> = memo(props => {
+    const { close, submit } = props;
+    const [name, setName] = useState<string>('');
+
+    const onChange = useCallback((evt: any) => {
+        setName(evt.target.value);
+    }, []);
+
+    const _submit = useCallback((evt: any) => {
+        submit(name?.trim());
+    }, [submit, name]);
+
+    return (
+        <Modal show={true} onHide={close}>
+            <Modal.Header>Create Subfolder</Modal.Header>
+            <Modal.Body>
+                <Form>
+                    <Row className="form-group">
+                        <Col xs={4}>
+                            <div>Subfolder Name:</div>
+                        </Col>
+                        <Col xs={8}>
+                            <FormControl type="text" id={'subfolder-name'} name={'subfolder-name'} onChange={onChange} />
+                        </Col>
+                    </Row>
+                </Form>
+                <Row>
+                    <Col xs={12}>
+                        <Button onClick={close} className="pull-left">
+                            Cancel
+                        </Button>
+                        <Button
+                            className="pull-right"
+                            bsStyle="success"
+                            disabled={name?.trim().length === 0}
+                            onClick={_submit}
+                        >
+                            Submit
+                        </Button>
+                    </Col>
+                </Row>
+            </Modal.Body>
+        </Modal>
+    )
+});

--- a/demo/src/client/FileAttachmentPage/FileDisplayPanel.tsx
+++ b/demo/src/client/FileAttachmentPage/FileDisplayPanel.tsx
@@ -6,11 +6,11 @@ import { createWebDavDirectory, LoadingSpinner } from '@labkey/components';
 import { MY_ATTACHMENTS_DIR } from "./constants";
 import { FileAttachmentModel, SavedFileModel } from "./models";
 import { getUploadedFiles } from "./actions";
-import { CreateSubfolderModal } from './CreateSubfolderModal';
+import { CreateDirectoryModal } from './CreateDirectoryModal';
 
 export const FileDisplayPanel : FC = memo(() => {
     const [loading, setLoading] = useState<boolean>(true);
-    const [showCreateSubfolderModal, setShowCreateSubfolderModal] = useState<boolean>();
+    const [showCreateDirectoryModal, setShowCreateDirectoryModal] = useState<boolean>();
     const [fileAttachmentModel, setFileAttachmentModel] = useState<FileAttachmentModel>(new FileAttachmentModel());
 
     //equivalent to componentDidMount and componentDidUpdate
@@ -33,15 +33,15 @@ export const FileDisplayPanel : FC = memo(() => {
             });
     }, [loading]);
 
-    const onCreateSubfolder = useCallback(() => {
-        setShowCreateSubfolderModal(true);
+    const onCreateDirectory = useCallback(() => {
+        setShowCreateDirectoryModal(true);
     }, []);
 
-    const closeCreateSubfolder = useCallback(() => {
-        setShowCreateSubfolderModal(false);
+    const closeCreateDirectory = useCallback(() => {
+        setShowCreateDirectoryModal(false);
     }, []);
 
-    const submitCreateSubfolder = useCallback((name: string) => {
+    const submitCreateDirectory = useCallback((name: string) => {
         let path = MY_ATTACHMENTS_DIR;
         if (!name?.startsWith('/')) path = path + '/';
         path = path + name;
@@ -52,8 +52,8 @@ export const FileDisplayPanel : FC = memo(() => {
                 setLoading(true);
             });
 
-        closeCreateSubfolder();
-    }, [closeCreateSubfolder]);
+        closeCreateDirectory();
+    }, [closeCreateDirectory]);
 
     return (
         <div className='panel panel-default'>
@@ -78,7 +78,7 @@ export const FileDisplayPanel : FC = memo(() => {
                 {
                     !loading && !fileAttachmentModel.savedFiles && (
                         <p>
-                            No files or subfolders to display. Use the panel above to upload files to this location.
+                            No files or directories to display. Use the panel above to upload files to this location.
                         </p>
                     )
                 }
@@ -89,12 +89,12 @@ export const FileDisplayPanel : FC = memo(() => {
                         })}>
                             Manage Files
                         </a>
-                        <a className='labkey-text-link' onClick={onCreateSubfolder}>
-                            Create Subfolder
+                        <a className='labkey-text-link' onClick={onCreateDirectory}>
+                            Create Directory
                         </a>
                     </p>
                 )}
-                {showCreateSubfolderModal && <CreateSubfolderModal close={closeCreateSubfolder} submit={submitCreateSubfolder} />}
+                {showCreateDirectoryModal && <CreateDirectoryModal close={closeCreateDirectory} submit={submitCreateDirectory} />}
             </div>
         </div>
     );


### PR DESCRIPTION
#### Rationale
In the tutorialModules/demo module, we have a React example page that uses the FileAttachmentForm component and the webdav related helper function to get and put files in the LKS filesystem via webdav. This PR updates that example page to include a "create subfolder" option that opens a modal and allows the user to enter in a new directory path to be used with the `createWebDavDirectory()` function.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/967

#### Changes
* update demo package.json @labkey/package version
* update FileAttachmentForm/FileDisplayPanel component with new modal for user entry of directory path and call to createWebDavDirectory()
