### PR TITLE
Upgrade to latest Java remote API

### DIFF
--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -7,7 +7,7 @@ gradlePluginsVersion=1.39.1
 # versions of artifacts required as dependencies
 #uncomment the version number and set to the desired labkeyVersion
 #labkeyVersion=22.11-SNAPSHOT
-labkeyClientApiVersion=5.0.1-fix_fixup-SNAPSHOT
+labkeyClientApiVersion=5.0.1
 
 # used by the LabKey Jsp Gradle plugin for declaring dependencies
 apacheTomcatVersion=9.0.70

--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -2,15 +2,15 @@
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 # Exact version will vary based on the version of LabKey being built on
-gradlePluginsVersion=1.36.0
+gradlePluginsVersion=1.39.1
 
 # versions of artifacts required as dependencies
 #uncomment the version number and set to the desired labkeyVersion
 #labkeyVersion=22.11-SNAPSHOT
-labkeyClientApiVersion=4.0.0
+labkeyClientApiVersion=5.0.1-fix_fixup-SNAPSHOT
 
 # used by the LabKey Jsp Gradle plugin for declaring dependencies
-apacheTomcatVersion=9.0.68
+apacheTomcatVersion=9.0.70
 servletApiVersion=4.0.1
 
 # Example external dependency used in build file


### PR DESCRIPTION
#### Rationale
v5.0.1 includes a data fix-up fix

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/49