### PR TITLE
Use artifactory repos that don't proxy for third-party repos

### DIFF
--- a/standalone/settings.gradle
+++ b/standalone/settings.gradle
@@ -1,9 +1,11 @@
 buildscript {
     repositories {
+        mavenCentral()
+        gradlePluginPortal()
         mavenLocal()
         // These repositories contain the LabKey gradle plugin
         maven {
-            url "${artifactory_contextUrl}/plugins-release"
+            url "${artifactory_contextUrl}/plugins-release-no-proxy"
         }
         maven {
             url "${artifactory_contextUrl}/plugins-snapshot-local"
@@ -31,11 +33,11 @@ gradle.beforeProject { project ->
         mavenCentral()
         maven {
             // Use this repository when relying on release versions of the LabKey artifacts and their external dependencies
-            url "${project.artifactory_contextUrl}/libs-release"
+            url "${project.artifactory_contextUrl}/libs-release-no-proxy"
         }
         maven {
             // Use this repository when relying on snapshot versions of LabKey artifacts
-            url "${project.artifactory_contextUrl}/libs-snapshot"
+            url "${project.artifactory_contextUrl}/libs-snapshot-no-proxy"
         }
     }
 }


### PR DESCRIPTION
#### Rationale
When we proxy for third-party repos, many of the artifacts that are available from mavenCentral get cached in and served from our Artifactory instance.  We want to avoid this to reduce costs.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/468

#### Changes
* Use non-proxying repos