### PR TITLE
Update dependencies to match develop

### DIFF
--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -2,15 +2,15 @@
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 # Exact version will vary based on the version of LabKey being built on
-gradlePluginsVersion=1.40.4
+gradlePluginsVersion=1.40.6
 
 # versions of artifacts required as dependencies
 #uncomment the version number and set to the desired labkeyVersion
 #labkeyVersion=23.3-SNAPSHOT
-labkeyClientApiVersion=5.1.0
+labkeyClientApiVersion=5.2.0
 
 # used by the LabKey Jsp Gradle plugin for declaring dependencies
-apacheTomcatVersion=9.0.73
+apacheTomcatVersion=9.0.75
 servletApiVersion=4.0.1
 
 # Example external dependency used in build file


### PR DESCRIPTION
#### Rationale
[[CVE-2023-28709] CWE-193: Off-by-one Error](https://ossindex.sonatype.org/vulnerability/CVE-2023-28709?component-type=maven&component-name=org.apache.tomcat%2Ftomcat-coyote&utm_source=dependency-check&utm_medium=integration&utm_content=8.2.1)

#### Related Pull Requests
* https://github.com/LabKey/server/pull/462

#### Changes
* Update dependencies to match develop 