### PR TITLE
Configure repository content for faster searching for dependencies

### DIFF
--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -2,7 +2,7 @@
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 # Exact version will vary based on the version of LabKey being built on
-gradlePluginsVersion=1.40.6
+gradlePluginsVersion=1.41.0
 
 # versions of artifacts required as dependencies
 #uncomment the version number and set to the desired labkeyVersion

--- a/standalone/noPlugins_build.gradle
+++ b/standalone/noPlugins_build.gradle
@@ -41,11 +41,17 @@ repositories
         {
             // Use this repository when relying on release versions of the LabKey artifacts and their external dependencies
             maven {
-                url "${project.artifactory_contextUrl}/libs-release"
+                url "${project.artifactory_contextUrl}/libs-release-no-proxy"
+                mavenContent {
+                    releasesOnly()
+                }
             }
             // Use this repository when relying on snapshot versions of LabKey artifacts or requiring snapshot external dependencies
             maven {
-                url "${project.artifactory_contextUrl}/libs-snapshot"
+                url "${project.artifactory_contextUrl}/libs-snapshot-no-proxy"
+                mavenContent {
+                    snapshotsOnly()
+                }
             }
             mavenCentral() // include the Maven Central repository separately in case lookup with previous repository fails
         }

--- a/standalone/settings.gradle
+++ b/standalone/settings.gradle
@@ -5,15 +5,21 @@ buildscript {
         // These repositories contain the LabKey gradle plugin
         maven {
             url "${artifactory_contextUrl}/plugins-release-no-proxy"
+            mavenContent {
+                releasesOnly()
+            }
         }
         maven {
             url "${artifactory_contextUrl}/plugins-snapshot-local"
+            mavenContent {
+                snapshotsOnly()
+            }
         }
     }
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }
-    configurations.all {
+    configurations.configureEach {
         // Check for updates every build for SNAPSHOT dependencies
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }
@@ -33,10 +39,22 @@ gradle.beforeProject { project ->
         maven {
             // Use this repository when relying on release versions of the LabKey artifacts and their external dependencies
             url "${project.artifactory_contextUrl}/libs-release-no-proxy"
+            mavenContent {
+                releasesOnly()
+            }
         }
         maven {
             // Use this repository when relying on snapshot versions of LabKey artifacts
             url "${project.artifactory_contextUrl}/libs-snapshot-no-proxy"
+            mavenContent {
+                snapshotsOnly()
+            }
+            content {
+                includeGroup "org.labkey"
+                includeGroup "org.labkey.api"
+                includeGroup "org.labkey.module"
+                includeGroup "org.maccosslab"
+            }
         }
     }
 }

--- a/standalone/settings.gradle
+++ b/standalone/settings.gradle
@@ -53,7 +53,6 @@ gradle.beforeProject { project ->
                 includeGroup "org.labkey"
                 includeGroup "org.labkey.api"
                 includeGroup "org.labkey.module"
-                includeGroup "org.maccosslab"
             }
         }
     }


### PR DESCRIPTION
#### Rationale
By default, every repository that is declared is searched for dependencies, which can be wasteful when we know that some repositories will never contain certain dependencies.  Gradle has introduced ways to [configure repositories](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering) to filter the content that is served from them, reducing search time and traffic to the repo server when looking for a dependency.  Might as well take advantage of that. 

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/177
* https://github.com/LabKey/server/pull/497

#### Changes
* Designate repos as either snapshot-only or release-only
* Filter to known groups for tool repository and snapshot repository
