### PR TITLE
CVE-2023-46589: upgrade tomcat version to 9.0.83

### DIFF
--- a/standalone/gradle.properties
+++ b/standalone/gradle.properties
@@ -10,7 +10,7 @@ gradlePluginsVersion=1.42.1
 labkeyClientApiVersion=5.3.0
 
 # used by the LabKey Jsp Gradle plugin for declaring dependencies
-apacheTomcatVersion=9.0.82
+apacheTomcatVersion=9.0.83
 servletApiVersion=4.0.1
 
 # Example external dependency used in build file


### PR DESCRIPTION
#### Rationale
[CVE-2023-46589](https://ossindex.sonatype.org/vulnerability/CVE-2023-46589?component-type=maven&component-name=org.apache.tomcat%2Ftomcat-coyote&utm_source=dependency-check&utm_medium=integration&utm_content=8.4.2): Though this is only an example module and there is no real threat from this CVE here, this should quiet the check failure. We already updated to 9.0.83 elsewhere for a different vulnerability.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/627

#### Changes
* tomcat version update
