### PR TITLE
 Remove react bootstrap usages

### DIFF
--- a/reactExamples/package-lock.json
+++ b/reactExamples/package-lock.json
@@ -8,7 +8,7 @@
       "name": "reactExamples",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.2"
+        "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.3"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3237,9 +3237,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.0.0-fb-remove-react-bootstrap-usages.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.2.tgz",
-      "integrity": "sha512-y6tNc+Tqa8Drj52gWbri3OvQjO0fYxfb4gHoDkPG/evr1fIe7Xm4N1p1DQRIX4vHMqvvzN/XZAxwhcKxsvxZlg==",
+      "version": "4.0.0-fb-remove-react-bootstrap-usages.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.3.tgz",
+      "integrity": "sha512-MXhc4t0RUBat14GhtsR6U9sfQOvtTgan4+D24pX0NZy54pL3FDS++I79M+J8tiqsyrcCtxtCdK78PQgIc8Y81g==",
       "dependencies": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
@@ -16937,9 +16937,9 @@
       }
     },
     "@labkey/components": {
-      "version": "4.0.0-fb-remove-react-bootstrap-usages.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.2.tgz",
-      "integrity": "sha512-y6tNc+Tqa8Drj52gWbri3OvQjO0fYxfb4gHoDkPG/evr1fIe7Xm4N1p1DQRIX4vHMqvvzN/XZAxwhcKxsvxZlg==",
+      "version": "4.0.0-fb-remove-react-bootstrap-usages.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.3.tgz",
+      "integrity": "sha512-MXhc4t0RUBat14GhtsR6U9sfQOvtTgan4+D24pX0NZy54pL3FDS++I79M+J8tiqsyrcCtxtCdK78PQgIc8Y81g==",
       "requires": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",

--- a/reactExamples/package-lock.json
+++ b/reactExamples/package-lock.json
@@ -8,7 +8,7 @@
       "name": "reactExamples",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.0"
+        "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.1"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3237,9 +3237,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.0.0-fb-remove-react-bootstrap-usages.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.0.tgz",
-      "integrity": "sha512-Ja3su+PNa77sXwwUrewiwxuubDblCjLGyLNufxqlVRaYz0e5Oh79TAIXDsIcOJuHe/Hh/Fql5nKaxD1F9Fcbzg==",
+      "version": "4.0.0-fb-remove-react-bootstrap-usages.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.1.tgz",
+      "integrity": "sha512-9VgeNXjL1eQYKKSID0NahIN3DkyRHpNrszG94jL2V+dbrL6Q1Yp1FlmbP1FCL6zHl8SrkX0iPYSvqwL/hKBuQQ==",
       "dependencies": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
@@ -16937,9 +16937,9 @@
       }
     },
     "@labkey/components": {
-      "version": "4.0.0-fb-remove-react-bootstrap-usages.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.0.tgz",
-      "integrity": "sha512-Ja3su+PNa77sXwwUrewiwxuubDblCjLGyLNufxqlVRaYz0e5Oh79TAIXDsIcOJuHe/Hh/Fql5nKaxD1F9Fcbzg==",
+      "version": "4.0.0-fb-remove-react-bootstrap-usages.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.1.tgz",
+      "integrity": "sha512-9VgeNXjL1eQYKKSID0NahIN3DkyRHpNrszG94jL2V+dbrL6Q1Yp1FlmbP1FCL6zHl8SrkX0iPYSvqwL/hKBuQQ==",
       "requires": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",

--- a/reactExamples/package-lock.json
+++ b/reactExamples/package-lock.json
@@ -8,7 +8,7 @@
       "name": "reactExamples",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.57.0-fb-remove-react-bootstrap-usages.6"
+        "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -1871,18 +1871,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime-corejs2": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.22.5.tgz",
-      "integrity": "sha512-GdiGeK5z8VKeJhqSQBgZr3xCMjAdborh5Ppn/0jQ0gtzw11UiZZAwDFZi0ZKvZ76ULooLqJn/OlrfcGZv7Pmzg==",
-      "dependencies": {
-        "core-js": "^2.6.12",
-        "regenerator-runtime": "^0.13.11"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
@@ -3249,9 +3237,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.57.0-fb-remove-react-bootstrap-usages.6",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.57.0-fb-remove-react-bootstrap-usages.6.tgz",
-      "integrity": "sha512-qHhPRPJJKP93o/TqaF2L07uA5PttjByasVXVx2/dhltjXUFgLFo0n39mONNIupG5EW3txoOjecBMeH+BXYK1hw==",
+      "version": "4.0.0-fb-remove-react-bootstrap-usages.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.0.tgz",
+      "integrity": "sha512-Ja3su+PNa77sXwwUrewiwxuubDblCjLGyLNufxqlVRaYz0e5Oh79TAIXDsIcOJuHe/Hh/Fql5nKaxD1F9Fcbzg==",
       "dependencies": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
@@ -3270,7 +3258,6 @@
         "numeral": "~2.0.6",
         "react": "~16.14.0",
         "react-beautiful-dnd": "~13.1.1",
-        "react-bootstrap": "~0.33.1",
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
         "react-dom": "~16.14.0",
@@ -3282,7 +3269,6 @@
       "peerDependencies": {
         "immutable": "^3.8.2",
         "react": "^16.0",
-        "react-bootstrap": "^0.33.1",
         "react-dom": "^16.0"
       }
     },
@@ -5675,13 +5661,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
-    },
     "node_modules/core-js-compat": {
       "version": "3.37.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
@@ -8012,14 +7991,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -10249,11 +10220,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/keycode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
-      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -11477,26 +11443,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types-extra": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "dependencies": {
-        "react-is": "^16.3.2",
-        "warning": "^4.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0"
-      }
-    },
-    "node_modules/prop-types-extra/node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -11723,29 +11669,6 @@
         }
       }
     },
-    "node_modules/react-bootstrap": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.33.1.tgz",
-      "integrity": "sha512-qWTRravSds87P8WC82tETy2yIso8qDqlIm0czsrduCaYAFtHuyLu0XDbUlfLXeRzqgwm5sRk2wRaTNoiVkk/YQ==",
-      "dependencies": {
-        "@babel/runtime-corejs2": "^7.0.0",
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.0",
-        "invariant": "^2.2.4",
-        "keycode": "^2.2.0",
-        "prop-types": "^15.6.1",
-        "prop-types-extra": "^1.0.1",
-        "react-overlays": "^0.9.0",
-        "react-prop-types": "^0.4.0",
-        "react-transition-group": "^2.0.0",
-        "uncontrollable": "^7.0.2",
-        "warning": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      }
-    },
     "node_modules/react-color": {
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
@@ -11822,23 +11745,6 @@
         "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
       }
     },
-    "node_modules/react-overlays": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.9.3.tgz",
-      "integrity": "sha512-u2T7nOLnK+Hrntho4p0Nxh+BsJl0bl4Xuwj/Y0a56xywLMetgAfyjnDVrudLXsNcKGaspoC+t3C1V80W9QQTdQ==",
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.1",
-        "prop-types": "^15.5.10",
-        "prop-types-extra": "^1.0.1",
-        "react-transition-group": "^2.2.1",
-        "warning": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      }
-    },
     "node_modules/react-popper": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
@@ -11859,17 +11765,6 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/react-prop-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-      "integrity": "sha512-IyjsJhDX9JkoOV9wlmLaS7z+oxYoIWhfzDcFy7inwoAKTu+VcVNrVpPmLeioJ94y6GeDRsnwarG1py5qofFQMg==",
-      "dependencies": {
-        "warning": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0"
       }
     },
     "node_modules/react-refresh": {
@@ -13688,20 +13583,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/uncontrollable": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
-      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.3",
-        "@types/react": ">=16.9.11",
-        "invariant": "^2.2.4",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0"
-      }
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -13950,14 +13831,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -15977,15 +15850,6 @@
         "regenerator-runtime": "^0.13.11"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.22.5.tgz",
-      "integrity": "sha512-GdiGeK5z8VKeJhqSQBgZr3xCMjAdborh5Ppn/0jQ0gtzw11UiZZAwDFZi0ZKvZ76ULooLqJn/OlrfcGZv7Pmzg==",
-      "requires": {
-        "core-js": "^2.6.12",
-        "regenerator-runtime": "^0.13.11"
-      }
-    },
     "@babel/template": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
@@ -17073,9 +16937,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.57.0-fb-remove-react-bootstrap-usages.6",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.57.0-fb-remove-react-bootstrap-usages.6.tgz",
-      "integrity": "sha512-qHhPRPJJKP93o/TqaF2L07uA5PttjByasVXVx2/dhltjXUFgLFo0n39mONNIupG5EW3txoOjecBMeH+BXYK1hw==",
+      "version": "4.0.0-fb-remove-react-bootstrap-usages.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.0.tgz",
+      "integrity": "sha512-Ja3su+PNa77sXwwUrewiwxuubDblCjLGyLNufxqlVRaYz0e5Oh79TAIXDsIcOJuHe/Hh/Fql5nKaxD1F9Fcbzg==",
       "requires": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17094,7 +16958,6 @@
         "numeral": "~2.0.6",
         "react": "~16.14.0",
         "react-beautiful-dnd": "~13.1.1",
-        "react-bootstrap": "~0.33.1",
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
         "react-dom": "~16.14.0",
@@ -19000,11 +18863,6 @@
         }
       }
     },
-    "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-    },
     "core-js-compat": {
       "version": "3.37.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
@@ -20689,14 +20547,6 @@
       "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -22294,11 +22144,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "keycode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
-      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -23200,25 +23045,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "prop-types-extra": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "requires": {
-        "react-is": "^16.3.2",
-        "warning": "^4.0.0"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -23382,25 +23208,6 @@
         }
       }
     },
-    "react-bootstrap": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.33.1.tgz",
-      "integrity": "sha512-qWTRravSds87P8WC82tETy2yIso8qDqlIm0czsrduCaYAFtHuyLu0XDbUlfLXeRzqgwm5sRk2wRaTNoiVkk/YQ==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.0.0",
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.0",
-        "invariant": "^2.2.4",
-        "keycode": "^2.2.0",
-        "prop-types": "^15.6.1",
-        "prop-types-extra": "^1.0.1",
-        "react-overlays": "^0.9.0",
-        "react-prop-types": "^0.4.0",
-        "react-transition-group": "^2.0.0",
-        "uncontrollable": "^7.0.2",
-        "warning": "^3.0.0"
-      }
-    },
     "react-color": {
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
@@ -23459,19 +23266,6 @@
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
       "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A=="
     },
-    "react-overlays": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.9.3.tgz",
-      "integrity": "sha512-u2T7nOLnK+Hrntho4p0Nxh+BsJl0bl4Xuwj/Y0a56xywLMetgAfyjnDVrudLXsNcKGaspoC+t3C1V80W9QQTdQ==",
-      "requires": {
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.1",
-        "prop-types": "^15.5.10",
-        "prop-types-extra": "^1.0.1",
-        "react-transition-group": "^2.2.1",
-        "warning": "^3.0.0"
-      }
-    },
     "react-popper": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
@@ -23489,14 +23283,6 @@
             "loose-envify": "^1.0.0"
           }
         }
-      }
-    },
-    "react-prop-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-      "integrity": "sha512-IyjsJhDX9JkoOV9wlmLaS7z+oxYoIWhfzDcFy7inwoAKTu+VcVNrVpPmLeioJ94y6GeDRsnwarG1py5qofFQMg==",
-      "requires": {
-        "warning": "^3.0.0"
       }
     },
     "react-refresh": {
@@ -24818,17 +24604,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "uncontrollable": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
-      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-      "requires": {
-        "@babel/runtime": "^7.6.3",
-        "@types/react": ">=16.9.11",
-        "invariant": "^2.2.4",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -24992,14 +24767,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
-      }
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/reactExamples/package-lock.json
+++ b/reactExamples/package-lock.json
@@ -8,7 +8,7 @@
       "name": "reactExamples",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.3"
+        "@labkey/components": "4.0.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3237,9 +3237,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.0.0-fb-remove-react-bootstrap-usages.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.3.tgz",
-      "integrity": "sha512-MXhc4t0RUBat14GhtsR6U9sfQOvtTgan4+D24pX0NZy54pL3FDS++I79M+J8tiqsyrcCtxtCdK78PQgIc8Y81g==",
+      "version": "4.0.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0.tgz",
+      "integrity": "sha512-yr9/9StNW8F/5RlGHhn0Nk0Pcdhzp6uTAXvkqfuZTpu88BCNLjzgb82xjJhYUufi0s1qaUasOmdirfWS3MbDBQ==",
       "dependencies": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
@@ -16937,9 +16937,9 @@
       }
     },
     "@labkey/components": {
-      "version": "4.0.0-fb-remove-react-bootstrap-usages.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.3.tgz",
-      "integrity": "sha512-MXhc4t0RUBat14GhtsR6U9sfQOvtTgan4+D24pX0NZy54pL3FDS++I79M+J8tiqsyrcCtxtCdK78PQgIc8Y81g==",
+      "version": "4.0.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0.tgz",
+      "integrity": "sha512-yr9/9StNW8F/5RlGHhn0Nk0Pcdhzp6uTAXvkqfuZTpu88BCNLjzgb82xjJhYUufi0s1qaUasOmdirfWS3MbDBQ==",
       "requires": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",

--- a/reactExamples/package-lock.json
+++ b/reactExamples/package-lock.json
@@ -8,7 +8,7 @@
       "name": "reactExamples",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.51.0"
+        "@labkey/components": "3.57.0-fb-remove-react-bootstrap-usages.6"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3208,9 +3208,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.0.tgz",
-      "integrity": "sha512-YSWDzkdK1ed+t7OtaFz9ZmCb2DEyVr7pdmZfVE7W0ZzBZHgfMiCUo9br0+g/dzqUXqxYBjuNgpJtbJhjObe2UQ=="
+      "version": "1.34.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1.tgz",
+      "integrity": "sha512-82dASLsBCq2IGecCIYNqFqbC1x/v/qIpH3rvd8e5S/VsFYjtAn9Xkd13DnDe0eO6+i0r54nSlIfLMtBCBKBchQ=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -3249,11 +3249,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.51.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.51.0.tgz",
-      "integrity": "sha512-R+rfDIC8lgCf9oBDJKgHRvwRcA0NkD6tYzbkUBc9/WDOsURmnPiBk0nIn4nV1I3SSpi73Ne9d55YA3P8A+huQg==",
+      "version": "3.57.0-fb-remove-react-bootstrap-usages.6",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.57.0-fb-remove-react-bootstrap-usages.6.tgz",
+      "integrity": "sha512-qHhPRPJJKP93o/TqaF2L07uA5PttjByasVXVx2/dhltjXUFgLFo0n39mONNIupG5EW3txoOjecBMeH+BXYK1hw==",
       "dependencies": {
-        "@labkey/api": "1.34.0",
+        "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -17032,9 +17032,9 @@
       "dev": true
     },
     "@labkey/api": {
-      "version": "1.34.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.0.tgz",
-      "integrity": "sha512-YSWDzkdK1ed+t7OtaFz9ZmCb2DEyVr7pdmZfVE7W0ZzBZHgfMiCUo9br0+g/dzqUXqxYBjuNgpJtbJhjObe2UQ=="
+      "version": "1.34.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1.tgz",
+      "integrity": "sha512-82dASLsBCq2IGecCIYNqFqbC1x/v/qIpH3rvd8e5S/VsFYjtAn9Xkd13DnDe0eO6+i0r54nSlIfLMtBCBKBchQ=="
     },
     "@labkey/build": {
       "version": "7.3.0",
@@ -17073,11 +17073,11 @@
       }
     },
     "@labkey/components": {
-      "version": "3.51.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.51.0.tgz",
-      "integrity": "sha512-R+rfDIC8lgCf9oBDJKgHRvwRcA0NkD6tYzbkUBc9/WDOsURmnPiBk0nIn4nV1I3SSpi73Ne9d55YA3P8A+huQg==",
+      "version": "3.57.0-fb-remove-react-bootstrap-usages.6",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.57.0-fb-remove-react-bootstrap-usages.6.tgz",
+      "integrity": "sha512-qHhPRPJJKP93o/TqaF2L07uA5PttjByasVXVx2/dhltjXUFgLFo0n39mONNIupG5EW3txoOjecBMeH+BXYK1hw==",
       "requires": {
-        "@labkey/api": "1.34.0",
+        "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/reactExamples/package-lock.json
+++ b/reactExamples/package-lock.json
@@ -8,7 +8,7 @@
       "name": "reactExamples",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.1"
+        "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.2"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3237,9 +3237,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.0.0-fb-remove-react-bootstrap-usages.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.1.tgz",
-      "integrity": "sha512-9VgeNXjL1eQYKKSID0NahIN3DkyRHpNrszG94jL2V+dbrL6Q1Yp1FlmbP1FCL6zHl8SrkX0iPYSvqwL/hKBuQQ==",
+      "version": "4.0.0-fb-remove-react-bootstrap-usages.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.2.tgz",
+      "integrity": "sha512-y6tNc+Tqa8Drj52gWbri3OvQjO0fYxfb4gHoDkPG/evr1fIe7Xm4N1p1DQRIX4vHMqvvzN/XZAxwhcKxsvxZlg==",
       "dependencies": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
@@ -16937,9 +16937,9 @@
       }
     },
     "@labkey/components": {
-      "version": "4.0.0-fb-remove-react-bootstrap-usages.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.1.tgz",
-      "integrity": "sha512-9VgeNXjL1eQYKKSID0NahIN3DkyRHpNrszG94jL2V+dbrL6Q1Yp1FlmbP1FCL6zHl8SrkX0iPYSvqwL/hKBuQQ==",
+      "version": "4.0.0-fb-remove-react-bootstrap-usages.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.0.0-fb-remove-react-bootstrap-usages.2.tgz",
+      "integrity": "sha512-y6tNc+Tqa8Drj52gWbri3OvQjO0fYxfb4gHoDkPG/evr1fIe7Xm4N1p1DQRIX4vHMqvvzN/XZAxwhcKxsvxZlg==",
       "requires": {
         "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",

--- a/reactExamples/package.json
+++ b/reactExamples/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
-    "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.2"
+    "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.3"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/reactExamples/package.json
+++ b/reactExamples/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
-    "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.1"
+    "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.2"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/reactExamples/package.json
+++ b/reactExamples/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
-    "@labkey/components": "3.51.0"
+    "@labkey/components": "3.57.0-fb-remove-react-bootstrap-usages.6"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/reactExamples/package.json
+++ b/reactExamples/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
-    "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.0"
+    "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.1"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/reactExamples/package.json
+++ b/reactExamples/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
-    "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.3"
+    "@labkey/components": "4.0.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/reactExamples/package.json
+++ b/reactExamples/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
-    "@labkey/components": "3.57.0-fb-remove-react-bootstrap-usages.6"
+    "@labkey/components": "4.0.0-fb-remove-react-bootstrap-usages.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/reactExamples/src/client/FileAttachmentPage/CreateDirectoryModal.tsx
+++ b/reactExamples/src/client/FileAttachmentPage/CreateDirectoryModal.tsx
@@ -1,5 +1,5 @@
-import React, { FC, memo, useCallback, useState } from 'react';
-import { Button, Col, Form, FormControl, Modal, Row } from 'react-bootstrap';
+import React, { ChangeEvent, FC, memo, useCallback, useState } from 'react';
+import { Modal } from '@labkey/components';
 
 interface Props {
     close: () => void;
@@ -10,44 +10,29 @@ export const CreateDirectoryModal : FC<Props> = memo(props => {
     const { close, submit } = props;
     const [name, setName] = useState<string>('');
 
-    const onChange = useCallback((evt: any) => {
+    const onChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
         setName(evt.target.value);
     }, []);
 
-    const _submit = useCallback((evt: any) => {
+    const _submit = useCallback(() => {
         submit(name?.trim());
     }, [submit, name]);
 
     return (
-        <Modal show={true} onHide={close}>
-            <Modal.Header>Create Directory</Modal.Header>
-            <Modal.Body>
-                <Form>
-                    <Row className="form-group">
-                        <Col xs={4}>
-                            <div>Directory Name:</div>
-                        </Col>
-                        <Col xs={8}>
-                            <FormControl type="text" id={'directory-name'} name={'directory-name'} onChange={onChange} />
-                        </Col>
-                    </Row>
-                </Form>
-                <Row>
-                    <Col xs={12}>
-                        <Button onClick={close} className="pull-left">
-                            Cancel
-                        </Button>
-                        <Button
-                            className="pull-right"
-                            bsStyle="success"
-                            disabled={name?.trim().length === 0}
-                            onClick={_submit}
-                        >
-                            Submit
-                        </Button>
-                    </Col>
-                </Row>
-            </Modal.Body>
+        <Modal
+            canConfirm={name?.trim().length === 0}
+            confirmText="Submit"
+            onCancel={close}
+            onConfirm={_submit} title="Create Directory"
+        >
+            <div className="form-group row">
+                <div className="col-xs-4">
+                    <div>Directory Name:</div>
+                </div>
+                <div className="col-xs-8">
+                    <input type="text" id={'directory-name'} name={'directory-name'} onChange={onChange}/>
+                </div>
+            </div>
         </Modal>
     )
 });

--- a/reactExamples/src/client/FileAttachmentPage/FileAttachmentPanel.tsx
+++ b/reactExamples/src/client/FileAttachmentPage/FileAttachmentPanel.tsx
@@ -3,7 +3,6 @@ import { FileAttachmentForm } from '@labkey/components';
 import { Map } from 'immutable';
 import { Draft, produce } from 'immer';
 import { FileAttachmentModel } from "./models";
-import { Panel } from 'react-bootstrap';
 
 interface Props {
     model: FileAttachmentModel;

--- a/reactExamples/tsconfig.json
+++ b/reactExamples/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "include": ["src/client/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
#### Rationale
We are dropping react-bootstrap as a dependency

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1525
- https://github.com/LabKey/labkey-ui-premium/pull/461
- https://github.com/LabKey/platform/pull/5649
- https://github.com/LabKey/limsModules/pull/421
- https://github.com/LabKey/testAutomation/pull/1975
- https://github.com/LabKey/tutorialModules/pull/190
- https://github.com/LabKey/moduleEditor/pull/108
- https://github.com/LabKey/provenance/pull/178

#### Changes
* Don't use react-bootstrap
* Add tsconfig.json
* bump components
