### PR TITLE
Update entryPoints.js to use permissionClasses instead of permission property

### DIFF
--- a/reactExamples/resources/views/demoWebpart.view.xml
+++ b/reactExamples/resources/views/demoWebpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="none" title="To-Do List Webpart">
-    <permissions>
-        <permission name="read"/>
-    </permissions>
+    <permissionClasses>
+        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+    </permissionClasses>
     <dependencies>
         <dependency path="gen/demoWebpart"/>
     </dependencies>

--- a/reactExamples/src/client/entryPoints.js
+++ b/reactExamples/src/client/entryPoints.js
@@ -7,12 +7,12 @@ module.exports = {
     apps: [{
         name: 'helloWorld',
         title: 'Hello World Page',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/HelloWorldPage'
     },{
         name: 'todoList',
         title: 'To-Do List Page',
-        permission: 'insert',
+        permissionClasses: ['org.labkey.api.security.permissions.InsertPermission'],
         path: './src/client/ToDoListPage'
     },{
         name: 'demoWebpart',
@@ -23,12 +23,12 @@ module.exports = {
     },{
         name: 'queryModel',
         title: 'QueryModel Example Page',
-        permission: 'read',
+        permissionClasses: ['org.labkey.api.security.permissions.ReadPermission'],
         path: './src/client/QueryModelPage'
     },{
         name: 'fileAttachmentForm',
         title: 'File Attachment Example Page',
-        permission: 'insert',
+        permissionClasses: ['org.labkey.api.security.permissions.InsertPermission'],
         path: './src/client/FileAttachmentPage'
     }]
 };

--- a/reactExamples/src/client/entryPoints.js
+++ b/reactExamples/src/client/entryPoints.js
@@ -17,7 +17,6 @@ module.exports = {
     },{
         name: 'demoWebpart',
         title: 'To-Do List Webpart',
-        permission: 'read',
         path: './src/client/ToDoListPage/webpart',
         generateLib: true // used by views/demoWebpart.html
     },{


### PR DESCRIPTION
#### Rationale
We are deprecating the `<permissions>` properties for the view.xml files. This PR migrates those usages to `<permissionClasses>`.

#### Changes
- Update entryPoints.js to use permissionClasses instead of permission property
- Remove entryPoints.js permission props for generateLib since they don't apply for libs
