### PR TITLE
Remove SupportedDatabases property now that default is PostgreSQL-only

### DIFF
--- a/exampleassay/module.properties
+++ b/exampleassay/module.properties
@@ -1,2 +1,1 @@
 ModuleClass: org.labkey.api.module.SimpleModule
-SupportedDatabases: pgsql

--- a/interactiveTutorial/module.properties
+++ b/interactiveTutorial/module.properties
@@ -1,3 +1,2 @@
 Name: 10MinuteTutorial
 RequiredServerVersion: 9.3
-SupportedDatabases: pgsql

--- a/reactExamples/module.properties
+++ b/reactExamples/module.properties
@@ -1,2 +1,1 @@
 ModuleClass: org.labkey.api.module.SimpleModule
-SupportedDatabases: pgsql

--- a/sourdough/module.properties
+++ b/sourdough/module.properties
@@ -1,3 +1,2 @@
 Name: Sourdough
 ModuleClass: org.labkey.api.module.SimpleModule
-SupportedDatabases: pgsql


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6067