### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/reactExamples/resources/views/demoWebpart.view.xml
+++ b/reactExamples/resources/views/demoWebpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="none" title="To-Do List Webpart">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/demoWebpart"/>
     </dependencies>

--- a/sourdough/resources/views/dailylog.view.xml
+++ b/sourdough/resources/views/dailylog.view.xml
@@ -2,9 +2,9 @@
       title="Daily Log"
       template="body"
 >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <!--    local imports    -->
         <dependency path="dailylog/script.js"/>

--- a/sourdough/resources/views/dailylogSide.view.xml
+++ b/sourdough/resources/views/dailylogSide.view.xml
@@ -2,9 +2,9 @@
       title="Documentation: Views and Webparts"
       template="body"
 >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
     </dependencies>
 </view>

--- a/sourdough/resources/views/dashboard.view.xml
+++ b/sourdough/resources/views/dashboard.view.xml
@@ -2,9 +2,9 @@
       title="Dashboard"
       template="body"
 >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="dashboard/script.js"/>
         <dependency path="dashboard/styles.css"/>

--- a/sourdough/resources/views/dashboardSide.view.xml
+++ b/sourdough/resources/views/dashboardSide.view.xml
@@ -2,9 +2,9 @@
       title="Documentation: Queries and Reports"
       template="body"
 >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
     </dependencies>
 </view>

--- a/sourdough/resources/views/overview.view.xml
+++ b/sourdough/resources/views/overview.view.xml
@@ -2,9 +2,9 @@
       title="Sourdough Overview"
       template="body"
 >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="overview/script.js"/>
         <dependency path="overview/styles.css"/>

--- a/sourdough/resources/views/overviewSide.view.xml
+++ b/sourdough/resources/views/overviewSide.view.xml
@@ -2,9 +2,9 @@
       title="Further Reading"
       template="body"
 >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
     </dependencies>
 </view>

--- a/sourdough/resources/views/styling.view.xml
+++ b/sourdough/resources/views/styling.view.xml
@@ -3,9 +3,9 @@
       template="body"
       frame="none"
 >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="styling/script.js"/>
         <dependency path="styling/styles.css"/>

--- a/sourdough/resources/views/stylingSide.view.xml
+++ b/sourdough/resources/views/stylingSide.view.xml
@@ -2,9 +2,9 @@
       title="Documentation: Styling and Appearance"
       template="body"
 >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
     </dependencies>
 </view>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.